### PR TITLE
Add local metadata viewer to media forensics

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Detect manipulation, deepfakes and AI-generated media, and verify provenance.
 | [AI or Not](https://www.aiornot.com/) | — | Web | Service classifying images, audio and video as AI-generated or real, including deepfakes. |
 | [Reality Defender](https://www.realitydefender.com/) | — | Web | Multimodal deepfake-detection platform (web app + API/SDK) for image, video, audio and text. |
 | [Metadata2Go](https://www.metadata2go.com/) | — | Web | Free browser tool to view, edit and remove EXIF/metadata from images, video, audio and PDFs. |
+| [Metadata Remover](https://metadataremover.ai/metadata-viewer) | — | Web | Browser-based viewer exposing EXIF, GPS and device fields locally without uploading the evidence; can export a clean copy. |
 
 <p align="right">(<a href="#readme">⬆ back to top</a>)</p>
 ## 🗺️ Geolocation & GEOINT


### PR DESCRIPTION
Adds [Metadata Remover](https://metadataremover.ai/metadata-viewer) to Image, Video & Media Forensics.

The viewer exposes EXIF, GPS and device fields locally in the browser without uploading investigative evidence, and can export a clean copy.

I maintain Metadata Remover. I evaluated the workflow directly and used the existing Web-tool table format. It differs from the listed Metadata2Go route by keeping the image local.