### PR TITLE
Add MyIPScan to Domain, DNS & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Footprint a target's domains, subdomains, DNS, certificates and tech stack from 
 | [alterx](https://github.com/projectdiscovery/alterx) | 991 | Go | Pattern-based subdomain wordlist/permutation generator for active enumeration. |
 | [Hurricane Electric BGP Toolkit](https://bgp.he.net) | — | Web | Web portal for ASN, BGP prefix, peering, and reverse-IP intelligence lookups. |
 | [RapidDNS](https://rapiddns.io) | — | Web | Free DNS query service for reverse-IP, subdomain, and shared-host lookups. |
+| [MyIPScan](https://myipscan.net/tools/) | — | Web | Browser-based lookups for IP, ASN, WHOIS/RDAP, reverse DNS, DNS records and provider IP ranges, plus DNS/WebRTC/IPv6 leak tests. |
 
 <p align="right">(<a href="#readme">⬆ back to top</a>)</p>
 


### PR DESCRIPTION
Adding MyIPScan to Domain, DNS & Infrastructure, alongside the other web-based lookup services (ViewDNS.info, RapidDNS, WHOIS/RDAP). Browser-based and free, no account: IP and ASN lookup, WHOIS/RDAP, reverse DNS, DNS records, provider IP ranges, plus DNS/WebRTC/IPv6 leak tests. Actively maintained.

Stars column set to - and Language to Web, matching the other hosted services in the table. Disclosure: I maintain this site. Happy for you to close this if it does not meet the bar.

## What does this PR do?

- [x] Adds a new tool
- [ ] Moves a tool to the Graveyard
- [ ] Fixes a broken link
- [ ] Other: ___

## Checklist

- [x] Tool is in the correct category
- [x] Description is one sentence and ends with a period
- [x] Link points to official repo or site
- [x] Tool is not already on the list
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
