### PR TITLE
Add MetadataRemover.ai to media forensics

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Detect manipulation, deepfakes and AI-generated media, and verify provenance.
 | [AI or Not](https://www.aiornot.com/) | — | Web | Service classifying images, audio and video as AI-generated or real, including deepfakes. |
 | [Reality Defender](https://www.realitydefender.com/) | — | Web | Multimodal deepfake-detection platform (web app + API/SDK) for image, video, audio and text. |
 | [Metadata2Go](https://www.metadata2go.com/) | — | Web | Free browser tool to view, edit and remove EXIF/metadata from images, video, audio and PDFs. |
+| [MetadataRemover.ai](https://metadataremover.ai/) | — | Web | Browser-local toolkit to inspect, remove, edit and verify supported image, document, video and audio metadata without uploads or an account. |
 
 <p align="right">(<a href="#readme">⬆ back to top</a>)</p>
 ## 🗺️ Geolocation & GEOINT


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Moves a tool to the Graveyard
- [ ] Fixes a broken link
- [ ] Other

## Summary

Adds MetadataRemover.ai to Image, Video & Media Forensics alongside the existing metadata tools. The entry describes the free browser-local workflow and uses the official site.

## Checklist

- [x] Tool is in the correct category
- [x] Description is one sentence and ends with a period
- [x] Link points to the official site
- [x] Tool is not already on the list
- [x] I have read CONTRIBUTING.md

Disclosure: I maintain MetadataRemover.ai.