### PR TITLE
Add isGenAI saved image metadata checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Detect manipulation, deepfakes and AI-generated media, and verify provenance.
 | [FaceForensics++](https://github.com/ondyari/FaceForensics) | 3k | Python | Benchmark dataset and detection code for face-manipulation methods. ⚠️ |
 | [InVID-WeVerify Plugin](https://weverify.eu/verification-plugin/) | — | Web | Browser-extension verification toolbox: video keyframes, magnifier, metadata, reverse search. |
 | [MeVer Verification Assistant](https://mever.iti.gr/forensics/) | — | Web | CERTH service bundling tampering-detection, EXIF, GPS and reverse-search for media verification. |
+| [isGenAI](https://isgenai.com/ai-image-detector) | — | Web | Commercial hosted service with free, no-account image checks: reads AI labels and saved generation settings, including supported A1111 and ComfyUI prompts. Files are uploaded for analysis. |
 | [Deepware Scanner](https://scanner.deepware.ai/) | — | Web | Free online scanner analyzing videos for facial-manipulation deepfakes with confidence scores. |
 | [Content Credentials Verify](https://contentcredentials.org/verify) | — | Web | Official CAI tool to inspect C2PA provenance manifests embedded in images, video and files. |
 | [c2patool](https://github.com/contentauth/c2pa-rs) | 415 | Rust | Official C2PA SDK and CLI to read, verify and write content-provenance manifests. |


### PR DESCRIPTION
Adds isGenAI under Image, Video & Media Forensics for inspecting AI labels and saved image-generation settings. The entry labels it as a commercial hosted service with free checks and explicitly states that files are uploaded.

The useful distinction for an investigator is recovering supported A1111 and ComfyUI prompts from the original image file, then comparing it with a copy whose metadata was removed. This helps inspect creation details; it does not establish that an image is true or false. Missing metadata does not establish human authorship.

Evaluated on September 13, 2026 with the working web/API image flow and paired public CC0 examples. The saved-only API returned the embedded prompt for the metadata-bearing image and HTTP 422/no_saved_prompt for its stripped counterpart, without calling a generation model. The guide includes the files and instructions: https://isgenai.com/guides/how-to-check-ai-image#examples. Current executable examples: https://github.com/vagabond11/isgenai-examples.

No duplicate isGenAI entry or proposal was found. This is a hosted service, so the stars column is left as a dash; the public repository contains examples, not the full service source. The web/API functionality is live and does not require an account for these checks.

Disclosure: submitted from the maker's account with an AI coding assistant helping prepare the entry and run the checks. Please assess it on its usefulness for the list.
